### PR TITLE
Support 'Class::method' syntax for callables

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ $invoker->call(function ($name = 'world') {
 
 // Invoke any PHP callable
 $invoker->call(['MyClass', 'myStaticMethod']);
+
+// Using Class::method syntax
+$invoker->call('MyClass::myStaticMethod');
 ```
 
 Dependency injection in parameters is supported but needs to be configured with your container. Read on or jump to [*Built-in support for dependency injection*](#built-in-support-for-dependency-injection) if you are impatient.
@@ -222,6 +225,8 @@ $invoker->call(['WelcomeController', 'home']);
 $invoker = new Invoker\Invoker(null, $container);
 // Now 'WelcomeController' is resolved using the container!
 $invoker->call(['WelcomeController', 'home']);
+// Alternatively we can use the Class::method syntax
+$invoker->call('WelcomeController::home');
 ```
 
 That feature can be used as the base building block for a framework's dispatcher.

--- a/src/Invoker.php
+++ b/src/Invoker.php
@@ -40,6 +40,10 @@ class Invoker implements InvokerInterface
      */
     public function call($callable, array $parameters = array())
     {
+        if (is_string($callable) && strpos($callable, '::') !== false) {
+            $callable = explode('::', $callable, 2);
+        }
+
         if ($this->container) {
             $callable = $this->resolveCallableFromContainer($callable);
         }

--- a/tests/InvokerTest.php
+++ b/tests/InvokerTest.php
@@ -64,6 +64,16 @@ class InvokerTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function should_invoke_static_method_with_scope_resolution_syntax()
+    {
+        $result = $this->invoker->call('Invoker\Test\InvokerTestStaticFixture::foo');
+
+        $this->assertEquals('bar', $result);
+    }
+
+    /**
+     * @test
+     */
     public function should_return_the_callable_return_value()
     {
         $result = $this->invoker->call(function () {
@@ -211,12 +221,40 @@ class InvokerTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function should_resolve_callable_from_container_with_scope_resolution_syntax()
+    {
+        $fixture = new InvokerTestFixture;
+        $this->container->set('thing-to-call', $fixture);
+
+        $result = $this->invoker->call('thing-to-call::foo');
+
+        $this->assertEquals('bar', $result);
+        $this->assertTrue($fixture->wasCalled);
+    }
+
+    /**
+     * @test
+     */
     public function should_resolve_array_callable_from_container_with_class_name()
     {
         $fixture = new InvokerTestFixture;
         $this->container->set('Invoker\Test\InvokerTestFixture', $fixture);
 
         $result = $this->invoker->call(array('Invoker\Test\InvokerTestFixture', 'foo'));
+
+        $this->assertEquals('bar', $result);
+        $this->assertTrue($fixture->wasCalled);
+    }
+
+    /**
+     * @test
+     */
+    public function should_resolve_callable_from_container_with_class_name_in_scope_resolution_syntax()
+    {
+        $fixture = new InvokerTestFixture;
+        $this->container->set('Invoker\Test\InvokerTestFixture', $fixture);
+
+        $result = $this->invoker->call('Invoker\Test\InvokerTestFixture::foo');
 
         $this->assertEquals('bar', $result);
         $this->assertTrue($fixture->wasCalled);


### PR DESCRIPTION
Closes https://github.com/PHP-DI/PHP-DI/issues/272 and https://github.com/PHP-DI/Silex-Bridge/issues/1
