### PR TITLE
Add TypeHintResolver

### DIFF
--- a/src/ParameterResolver/TypeHintResolver.php
+++ b/src/ParameterResolver/TypeHintResolver.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Invoker\ParameterResolver;
+
+use Invoker\ParameterResolver\ParameterResolver;
+use ReflectionFunctionAbstract;
+
+/**
+ * Inject entries using type-hints.
+ *
+ * @author Felix Becker <f.becker@outlook.com>
+ */
+class TypeHintResolver implements ParameterResolver
+{
+    public function getParameters(
+        ReflectionFunctionAbstract $reflection,
+        array $providedParameters,
+        array $resolvedParameters
+    ) {
+        $parameters = $reflection->getParameters();
+
+        // Skip parameters already resolved
+        if (! empty($resolvedParameters)) {
+            $parameters = array_diff_key($parameters, $resolvedParameters);
+        }
+
+        foreach ($parameters as $index => $parameter) {
+            $parameterClass = $parameter->getClass();
+
+            if ($parameterClass && array_key_exists($parameterClass->name, $providedParameters)) {
+                $resolvedParameters[$index] = $providedParameters[$parameterClass->name];
+            }
+        }
+
+        return $resolvedParameters;
+    }
+}

--- a/tests/ParameterResolver/TypeHintResolverTest.php
+++ b/tests/ParameterResolver/TypeHintResolverTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Invoker\Test\ParameterResolver;
+
+use Invoker\ParameterResolver\TypeHintResolver;
+
+class TypeHintResolverTest extends \PHPUnit_Framework_TestCase
+{
+    const FIXTURE = 'Invoker\Test\ParameterResolver\TypeHintResolverFixture';
+
+    /**
+     * @var TypeHintResolver
+     */
+    private $resolver;
+
+    public function setUp()
+    {
+        $this->resolver = new TypeHintResolver;
+    }
+
+    /**
+     * @test
+     */
+    public function should_resolve_parameter_with_typehint()
+    {
+        $callable = function (TypeHintResolverFixture $foo) {};
+        $reflection = new \ReflectionFunction($callable);
+
+        $fixture = new TypeHintResolverFixture;
+
+        $parameters = $this->resolver->getParameters($reflection, array(self::FIXTURE => $fixture), array());
+
+        $this->assertCount(1, $parameters);
+        $this->assertSame($fixture, $parameters[0]);
+    }
+
+    /**
+     * @test
+     */
+    public function should_skip_parameter_if_provided_parameters_do_not_contain_typehint()
+    {
+        $callable = function (TypeHintResolverFixture $foo) {};
+        $reflection = new \ReflectionFunction($callable);
+
+        $parameters = $this->resolver->getParameters($reflection, array(), array());
+
+        $this->assertCount(0, $parameters);
+    }
+
+    /**
+     * @test
+     */
+    public function should_skip_parameter_if_already_resolved()
+    {
+        $callable = function (TypeHintResolverFixture $foo) {};
+        $reflection = new \ReflectionFunction($callable);
+
+        $fixture = new TypeHintResolverFixture;
+
+        $resolvedParameters = array('first param value');
+        $parameters = $this->resolver->getParameters($reflection, array(self::FIXTURE => $fixture), $resolvedParameters);
+
+        $this->assertSame($resolvedParameters, $parameters);
+    }
+}
+
+class TypeHintResolverFixture
+{
+}


### PR DESCRIPTION
This implements @mnapoli's proposal from https://github.com/PHP-DI/Silex-Bridge/pull/16#issuecomment-197990675:

> What we could do is create a new type of ParameterResolver that checks the type-hint, but not for container entries. Example of usage:
> 
> ``` php
> $parameterResolver = new ResolverChain([
>    new AssociativeArrayResolver, // inject request/response by name
>    new TypeHintResolver, // inject request/response by type-hint
>    new TypeHintContainerResolver, // dependency injection
> ]);
> 
> ...
> 
> $invoker->call($middleware, [
>    'request' => $request, // by name, used by AssociativeArrayResolver
>    'response' => $response, // by name, used by AssociativeArrayResolver
>    'Symfony\...\Request' => $request, // by type-hint, used by TypeHintResolver
>    'Symfony\...\Response' => $request, // by type-hint, used by TypeHintResolver
> ]);
> ```
> 
> The TypeHintResolver could be reused by other bridges later (e.g. Slim framework). It could be added directly to the Invoker project.

Semver Minor.
