### PR TITLE
Explicit exception message for unsupported magic methods

### DIFF
--- a/src/CallableResolver.php
+++ b/src/CallableResolver.php
@@ -40,7 +40,7 @@ class CallableResolver
         $callable = $this->resolveFromContainer($callable);
 
         if (! is_callable($callable)) {
-            throw NotCallableException::fromInvalidCallable($callable);
+            throw NotCallableException::fromInvalidCallable($callable, true);
         }
 
         return $callable;
@@ -73,10 +73,7 @@ class CallableResolver
             if ($this->container->has($callable)) {
                 return $this->container->get($callable);
             } else {
-                throw new NotCallableException(sprintf(
-                    '"%s" is neither a callable nor a valid container entry',
-                    $callable
-                ));
+                throw NotCallableException::fromInvalidCallable($callable, true);
             }
         }
 

--- a/src/Exception/NotCallableException.php
+++ b/src/Exception/NotCallableException.php
@@ -11,16 +11,23 @@ class NotCallableException extends InvocationException
 {
     /**
      * @param string $value
+     * @param bool $containerEntry
      * @return self
      */
-    public static function fromInvalidCallable($value)
+    public static function fromInvalidCallable($value, $containerEntry = false)
     {
         if (is_object($value)) {
             $message = sprintf('Instance of %s is not a callable', get_class($value));
-        } elseif (is_array($value) && isset($value[0]) && isset($value[1]) && is_object($value[0])) {
-            $message = sprintf('%s::%s() is not a callable', get_class($value[0]), $value[1]);
+        } elseif (is_array($value) && isset($value[0]) && isset($value[1])) {
+            $class = is_object($value[0]) ? get_class($value[0]) : $value[0];
+            $extra = method_exists($class, '__call') ? ' A __call() method exists but magic methods are not supported.' : '';
+            $message = sprintf('%s::%s() is not a callable.%s', $class, $value[1], $extra);
         } else {
-            $message = var_export($value, true) . ' is neither a callable nor a valid container entry';
+            if ($containerEntry) {
+                $message = var_export($value, true) . ' is neither a callable nor a valid container entry';
+            } else {
+                $message = var_export($value, true) . ' is not a callable';
+            }
         }
 
         return new self($message);

--- a/src/Reflection/CallableReflection.php
+++ b/src/Reflection/CallableReflection.php
@@ -31,6 +31,10 @@ class CallableReflection
         if (is_array($callable)) {
             list($class, $method) = $callable;
 
+            if (! method_exists($class, $method)) {
+                throw NotCallableException::fromInvalidCallable($callable);
+            }
+
             return new \ReflectionMethod($class, $method);
         }
 

--- a/tests/CallableResolverTest.php
+++ b/tests/CallableResolverTest.php
@@ -125,7 +125,7 @@ class CallableResolverTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      * @expectedException \Invoker\Exception\NotCallableException
-     * @expectedExceptionMessage "foo" is neither a callable nor a valid container entry
+     * @expectedExceptionMessage 'foo' is neither a callable nor a valid container entry
      */
     public function throws_resolving_non_callable_from_container()
     {

--- a/tests/InvokerTest.php
+++ b/tests/InvokerTest.php
@@ -53,6 +53,26 @@ class InvokerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     * @expectedException \Invoker\Exception\NotCallableException
+     * @expectedExceptionMessage Invoker\Test\InvokerTestFixture::bar() is not a callable.
+     */
+    public function cannot_invoke_unknown_method()
+    {
+        $this->invoker->call(array(new InvokerTestFixture, 'bar'));
+    }
+
+    /**
+     * @test
+     * @expectedException \Invoker\Exception\NotCallableException
+     * @expectedExceptionMessage Invoker\Test\InvokerTestMagicMethodFixture::foo() is not a callable. A __call() method exists but magic methods are not supported.
+     */
+    public function cannot_invoke_magic_method()
+    {
+        $this->invoker->call(array(new InvokerTestMagicMethodFixture, 'foo'));
+    }
+
+    /**
+     * @test
      */
     public function should_invoke_static_method()
     {
@@ -295,7 +315,7 @@ class InvokerTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      * @expectedException \Invoker\Exception\NotCallableException
-     * @expectedExceptionMessage "foo" is neither a callable nor a valid container entry
+     * @expectedExceptionMessage 'foo' is neither a callable nor a valid container entry
      */
     public function should_throw_if_calling_non_callable_with_container()
     {
@@ -385,5 +405,18 @@ class InvokerTestStaticFixture
     public static function foo()
     {
         return 'bar';
+    }
+}
+
+class InvokerTestMagicMethodFixture
+{
+    public $wasCalled = false;
+    public function __call($name, $args)
+    {
+        if ($name === 'foo') {
+            $this->wasCalled = true;
+            return 'bar';
+        }
+        throw new \Exception('Unknown method');
     }
 }


### PR DESCRIPTION
Fixes https://github.com/PHP-DI/PHP-DI/issues/422

When trying to call a magic method, a `Invoker\Exception\NotCallableException` exception will be thrown with message:

> MyClass::foo() is not a callable. A __call() method exists but magic methods are not supported.
