### PR TITLE
Avoid calls to Container::has() that can be avoided

### DIFF
--- a/tests/Mock/ArrayContainer.php
+++ b/tests/Mock/ArrayContainer.php
@@ -18,6 +18,10 @@ class ArrayContainer implements ContainerInterface
 
     public function get($id)
     {
+        if (!array_key_exists($id, $this->entries)) {
+            throw new NotFound;
+        }
+
         return $this->entries[$id];
     }
 

--- a/tests/Mock/NotFound.php
+++ b/tests/Mock/NotFound.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types = 1);
+
+namespace Invoker\Test\Mock;
+
+use Interop\Container\Exception\NotFoundException;
+
+class NotFound extends \Exception implements NotFoundException
+{
+}


### PR DESCRIPTION
That could be a small performance improvement, in http://externals.io those calls are visible in profiling.

TODO :
- [x] check performance difference: saved approximately 1 ms (5% of the total page time)
