### PR TITLE
Migrate to PSR-11

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,12 +164,12 @@ Rather than have you re-implement support for dependency injection with differen
 
     In this example it will `->get('twig')` from the container and inject it.
 
-These resolvers can work with any dependency injection container compliant with [container-interop](https://github.com/container-interop/container-interop). If you container is not compliant you can use the [Acclimate](https://github.com/jeremeamia/acclimate-container) package.
+These resolvers can work with any dependency injection container compliant with [PSR-11](http://www.php-fig.org/psr/psr-11/).
 
 Setting up those resolvers is simple:
 
 ```php
-// $container must be an instance of Interop\Container\ContainerInterface
+// $container must be an instance of Psr\Container\ContainerInterface
 $container = ...
 
 $containerResolver = new TypeHintContainerResolver($container);
@@ -231,4 +231,4 @@ $invoker->call('WelcomeController::home');
 
 That feature can be used as the base building block for a framework's dispatcher.
 
-Again, any [container-interop](https://github.com/container-interop/container-interop) compliant container can be provided, and [Acclimate](https://github.com/jeremeamia/acclimate-container) can be used for incompatible containers.
+Again, any [PSR-11](http://www.php-fig.org/psr/psr-11/) compliant container can be provided.

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     },
     "require": {
-        "container-interop/container-interop": "~1.1"
+        "psr/container": "~1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.5",

--- a/src/CallableResolver.php
+++ b/src/CallableResolver.php
@@ -2,9 +2,9 @@
 
 namespace Invoker;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\NotFoundException;
 use Invoker\Exception\NotCallableException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
 
 /**
  * Resolves a callable from a container.
@@ -73,7 +73,10 @@ class CallableResolver
         if (is_string($callable)) {
             try {
                 return $this->container->get($callable);
-            } catch (NotFoundException $e) {
+            } catch (NotFoundExceptionInterface $e) {
+                if ($this->container->has($callable)) {
+                    throw $e;
+                }
                 throw NotCallableException::fromInvalidCallable($callable, true);
             }
         }
@@ -85,7 +88,10 @@ class CallableResolver
                 // Replace the container entry name by the actual object
                 $callable[0] = $this->container->get($callable[0]);
                 return $callable;
-            } catch (NotFoundException $e) {
+            } catch (NotFoundExceptionInterface $e) {
+                if ($this->container->has($callable[0])) {
+                    throw $e;
+                }
                 if ($isStaticCallToNonStaticMethod) {
                     throw new NotCallableException(sprintf(
                         'Cannot call %s::%s() because %s() is not a static method and "%s" is not a container entry',

--- a/src/Invoker.php
+++ b/src/Invoker.php
@@ -2,7 +2,6 @@
 
 namespace Invoker;
 
-use Interop\Container\ContainerInterface;
 use Invoker\Exception\NotCallableException;
 use Invoker\Exception\NotEnoughParametersException;
 use Invoker\ParameterResolver\AssociativeArrayResolver;
@@ -11,6 +10,7 @@ use Invoker\ParameterResolver\NumericArrayResolver;
 use Invoker\ParameterResolver\ParameterResolver;
 use Invoker\ParameterResolver\ResolverChain;
 use Invoker\Reflection\CallableReflection;
+use Psr\Container\ContainerInterface;
 
 /**
  * Invoke a callable.

--- a/src/ParameterResolver/Container/ParameterNameContainerResolver.php
+++ b/src/ParameterResolver/Container/ParameterNameContainerResolver.php
@@ -2,8 +2,8 @@
 
 namespace Invoker\ParameterResolver\Container;
 
-use Interop\Container\ContainerInterface;
 use Invoker\ParameterResolver\ParameterResolver;
+use Psr\Container\ContainerInterface;
 use ReflectionFunctionAbstract;
 
 /**

--- a/src/ParameterResolver/Container/TypeHintContainerResolver.php
+++ b/src/ParameterResolver/Container/TypeHintContainerResolver.php
@@ -2,8 +2,8 @@
 
 namespace Invoker\ParameterResolver\Container;
 
-use Interop\Container\ContainerInterface;
 use Invoker\ParameterResolver\ParameterResolver;
+use Psr\Container\ContainerInterface;
 use ReflectionFunctionAbstract;
 
 /**

--- a/tests/Mock/ArrayContainer.php
+++ b/tests/Mock/ArrayContainer.php
@@ -2,7 +2,7 @@
 
 namespace Invoker\Test\Mock;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * Simple container.

--- a/tests/Mock/NotFound.php
+++ b/tests/Mock/NotFound.php
@@ -3,8 +3,8 @@ declare(strict_types = 1);
 
 namespace Invoker\Test\Mock;
 
-use Interop\Container\Exception\NotFoundException;
+use Psr\Container\NotFoundExceptionInterface;
 
-class NotFound extends \Exception implements NotFoundException
+class NotFound extends \Exception implements NotFoundExceptionInterface
 {
 }


### PR DESCRIPTION
Drop container-interop support and migrate to PSR-11.

All container-interop containers are still usable though because container-interop extends PSR-11. The only BC break I can see is the `Invoker::getContainer()` method (which now returns a PSR-11 container).

This means it should be released as a new major version.