### PR TITLE
Allow for calling constructors by invoker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: trusty
+
 php:
   - 5.4
   - 5.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ before_script:
   - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest --prefer-stable -n; fi;
 
 script:
-  - if [[ "$TRAVIS_PHP_VERSION" == '5.6' ]]; then phpunit --coverage-clover clover.xml ; fi
-  - if [[ "$TRAVIS_PHP_VERSION" != '5.6' ]]; then phpunit ; fi
+  - if [[ "$TRAVIS_PHP_VERSION" == '5.6' ]]; then vendor/bin/phpunit --coverage-clover clover.xml ; fi
+  - if [[ "$TRAVIS_PHP_VERSION" != '5.6' ]]; then vendor/bin/phpunit ; fi
   - vendor/bin/athletic --path tests/Benchmark --formatter GroupedFormatter
 after_script:
   - if [[ "$TRAVIS_PHP_VERSION" == '5.6' ]]; then php vendor/bin/coveralls -v ; fi

--- a/src/Invoker.php
+++ b/src/Invoker.php
@@ -60,6 +60,22 @@ class Invoker implements InvokerInterface
             ));
         }
 
+        return call_user_func_array($callable, $this->getArgs($callable, $parameters));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create($className, array $parameters = array())
+    {
+        $className = (string) $className;
+        $classReflection = new \ReflectionClass($className);
+        
+        return $classReflection->newInstanceArgs($this->getArgs(array($className, '__construct'), $parameters));
+    }
+    
+    private function getArgs($callable, array $parameters)
+    {
         $callableReflection = CallableReflection::create($callable);
 
         $args = $this->parameterResolver->getParameters($callableReflection, $parameters, array());
@@ -78,8 +94,8 @@ class Invoker implements InvokerInterface
                 $parameter->name
             ));
         }
-
-        return call_user_func_array($callable, $args);
+        
+        return $args;
     }
 
     /**

--- a/src/InvokerInterface.php
+++ b/src/InvokerInterface.php
@@ -26,4 +26,13 @@ interface InvokerInterface
      * @throws NotEnoughParametersException
      */
     public function call($callable, array $parameters = array());
+
+    /**
+     * Create instance of the given class using the given parameters.
+     * 
+     * @param string $className
+     * @param array  $parameters
+     * @return object
+     */
+    public function create($className, array $parameters = array());
 }

--- a/src/Reflection/CallableReflection.php
+++ b/src/Reflection/CallableReflection.php
@@ -32,6 +32,12 @@ class CallableReflection
             list($class, $method) = $callable;
 
             if (! method_exists($class, $method)) {
+                if ('__construct' === $method) {
+                    return new \ReflectionFunction(function () use ($class) {
+                        return new $class;
+                    });
+                }
+                
                 throw NotCallableException::fromInvalidCallable($callable);
             }
 

--- a/tests/InvokerTest.php
+++ b/tests/InvokerTest.php
@@ -377,6 +377,38 @@ class InvokerTest extends \PHPUnit_Framework_TestCase
         ));
     }
 
+    /**
+     * @test
+     */
+    public function should_create_object()
+    {
+        $className = 'Invoker\Test\TestObject';
+        $parameters = array(
+            'd' => 'd value',
+            'b' => new \stdClass(),
+            'a' => 'a value',
+            'c' => 'c value',
+        );
+        
+        $invoker = new Invoker();
+        /** @var TestObject $testObject */
+        $testObject = $invoker->create($className, $parameters);
+        $this->assertSame($parameters['a'], $testObject->getA());
+        $this->assertSame($parameters['b'], $testObject->getB());
+        $this->assertSame($parameters['c'], $testObject->getC());
+    }
+
+    /**
+     * @test
+     */
+    public function should_create_object_without_constructor()
+    {
+        $className = 'Invoker\Test\TestObjectWithoutConstructor';
+        $invoker = new Invoker();
+        $object = $invoker->create($className);
+        $this->assertInstanceOf($className, $object);
+    }
+        
     private function assertWasCalled(CallableSpy $callableSpy)
     {
         $this->assertEquals(1, $callableSpy->getCallCount(), 'The callable should be called once');

--- a/tests/InvokerTest.php
+++ b/tests/InvokerTest.php
@@ -393,6 +393,7 @@ class InvokerTest extends \PHPUnit_Framework_TestCase
         $invoker = new Invoker();
         /** @var TestObject $testObject */
         $testObject = $invoker->create($className, $parameters);
+        $this->assertInstanceOf($className, $testObject);
         $this->assertSame($parameters['a'], $testObject->getA());
         $this->assertSame($parameters['b'], $testObject->getB());
         $this->assertSame($parameters['c'], $testObject->getC());

--- a/tests/Mock/NotFound.php
+++ b/tests/Mock/NotFound.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types = 1);
 
 namespace Invoker\Test\Mock;
 

--- a/tests/TestObject.php
+++ b/tests/TestObject.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Invoker\Test;
+
+class TestObject
+{
+    private $a;
+    
+    private $b;
+    
+    private $c;
+    
+    public function __construct($a, $b, $c)
+    {
+        $this->a = $a;
+        $this->b = $b;
+        $this->c = $c;
+    }
+    
+    public function getA()
+    {
+        return $this->a;
+    }
+    
+    public function getB()
+    {
+        return $this->b;
+    }
+    
+    public function getC()
+    {
+        return $this->c;
+    }
+}

--- a/tests/TestObjectWithoutConstructor.php
+++ b/tests/TestObjectWithoutConstructor.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Invoker\Test;
+
+class TestObjectWithoutConstructor
+{
+}


### PR DESCRIPTION
Would be nice to have an option to create new object by invoker.

**Why?**

Let's say that I'm going to create controller for web application. Usually code looks like the following:

```php
$controller = new $controllerClass($container);
```

IMO would be better to limit injected dependencies. Now code can look like the following:

```php
$invoker = new Invoker(null, $container);
$controller = $invoker->create($controllerClass);
```