### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "psr/container": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.5",
+        "phpunit/phpunit": "~4.8.35",
         "athletic/athletic": "~0.1.8"
     }
 }

--- a/tests/CallableResolverTest.php
+++ b/tests/CallableResolverTest.php
@@ -5,8 +5,9 @@ namespace Invoker\Test;
 use Invoker\CallableResolver;
 use Invoker\Test\Mock\ArrayContainer;
 use Invoker\Test\Mock\CallableSpy;
+use PHPUnit\Framework\TestCase;
 
-class CallableResolverTest extends \PHPUnit_Framework_TestCase
+class CallableResolverTest extends TestCase
 {
     /**
      * @var CallableResolver

--- a/tests/InvokerTest.php
+++ b/tests/InvokerTest.php
@@ -8,8 +8,9 @@ use Invoker\ParameterResolver\Container\ParameterNameContainerResolver;
 use Invoker\ParameterResolver\Container\TypeHintContainerResolver;
 use Invoker\Test\Mock\ArrayContainer;
 use Invoker\Test\Mock\CallableSpy;
+use PHPUnit\Framework\TestCase;
 
-class InvokerTest extends \PHPUnit_Framework_TestCase
+class InvokerTest extends TestCase
 {
     /**
      * @var Invoker

--- a/tests/ParameterResolver/Container/ParameterNameContainerResolverTest.php
+++ b/tests/ParameterResolver/Container/ParameterNameContainerResolverTest.php
@@ -4,8 +4,9 @@ namespace Invoker\Test\ParameterResolver\Container;
 
 use Invoker\ParameterResolver\Container\ParameterNameContainerResolver;
 use Invoker\Test\Mock\ArrayContainer;
+use PHPUnit\Framework\TestCase;
 
-class ParameterNameContainerResolverTest extends \PHPUnit_Framework_TestCase
+class ParameterNameContainerResolverTest extends TestCase
 {
     /**
      * @var ParameterNameContainerResolver

--- a/tests/ParameterResolver/Container/TypeHintContainerResolverTest.php
+++ b/tests/ParameterResolver/Container/TypeHintContainerResolverTest.php
@@ -4,8 +4,9 @@ namespace Invoker\Test\ParameterResolver\Container;
 
 use Invoker\ParameterResolver\Container\TypeHintContainerResolver;
 use Invoker\Test\Mock\ArrayContainer;
+use PHPUnit\Framework\TestCase;
 
-class TypeHintContainerResolverTest extends \PHPUnit_Framework_TestCase
+class TypeHintContainerResolverTest extends TestCase
 {
     const FIXTURE = 'Invoker\Test\ParameterResolver\Container\TypeHintContainerResolverFixture';
 

--- a/tests/ParameterResolver/TypeHintResolverTest.php
+++ b/tests/ParameterResolver/TypeHintResolverTest.php
@@ -3,8 +3,9 @@
 namespace Invoker\Test\ParameterResolver;
 
 use Invoker\ParameterResolver\TypeHintResolver;
+use PHPUnit\Framework\TestCase;
 
-class TypeHintResolverTest extends \PHPUnit_Framework_TestCase
+class TypeHintResolverTest extends TestCase
 {
     const FIXTURE = 'Invoker\Test\ParameterResolver\TypeHintResolverFixture';
 


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`~4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.