### PR TITLE
[#24] factory: optional parameter becomes factorydefinition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ dist: trusty
 
 before_script:
   - composer self-update
-  - if [[ "$TRAVIS_PHP_VERSION" == '5.6' ]]; then composer require satooshi/php-coveralls:dev-master -n ; fi
+  - if [[ "$TRAVIS_PHP_VERSION" == '5.6' ]]; then composer require satooshi/php-coveralls -n ; fi
   - if [[ "$TRAVIS_PHP_VERSION" != '5.6' ]]; then composer install -n ; fi
   - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest --prefer-stable -n; fi;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
 
 sudo: false
 
+dist: trusty
+
 before_script:
   - composer self-update
   - if [[ "$TRAVIS_PHP_VERSION" == '5.6' ]]; then composer require satooshi/php-coveralls:dev-master -n ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ dist: trusty
 before_script:
   - composer self-update
   - if [[ "$TRAVIS_PHP_VERSION" == '5.6' ]]; then composer require satooshi/php-coveralls -n ; fi
-  - if [[ "$TRAVIS_PHP_VERSION" != '5.6' ]]; then composer install -n ; fi
+  - if [[ "$TRAVIS_PHP_VERSION" != '5.6' ]]; then composer self-update --snapshot && composer install -n ; fi
   - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest --prefer-stable -n; fi;
 
 script:

--- a/src/ParameterResolver/NumericArrayResolver.php
+++ b/src/ParameterResolver/NumericArrayResolver.php
@@ -29,7 +29,7 @@ class NumericArrayResolver implements ParameterResolver
         }
 
         foreach ($providedParameters as $key => $value) {
-            if (is_int($key)) {
+            if (is_int($key) && ! is_object($value)) {
                 $resolvedParameters[$key] = $value;
             }
         }

--- a/tests/InvokerTest.php
+++ b/tests/InvokerTest.php
@@ -207,21 +207,6 @@ class InvokerTest extends TestCase
     /**
      * @test
      */
-    public function test_should_override_value_for_trailing_optional_parameters()
-    {
-        $res = $this->invoker->call(function ($foo, $bar = 300.0, $baz = true) {
-            return [$foo, $bar, $baz];
-        }, array(
-            'foo' => 'foo',
-            new \stdClass(),
-            'bar' => 50.0,
-        ));
-        $this->assertEquals(["foo", 50.0, true], $res);
-    }
-
-    /**
-     * @test
-     */
     public function should_do_dependency_injection_with_typehint_container_resolver()
     {
         $resolver = new TypeHintContainerResolver($this->container);

--- a/tests/InvokerTest.php
+++ b/tests/InvokerTest.php
@@ -179,6 +179,49 @@ class InvokerTest extends TestCase
     /**
      * @test
      */
+    public function should_override_value_for_trailing_optional_parameters()
+    {
+        $assetions = [
+            'expected' => [
+                ["foo", 300.0, true],
+                ["foo", 50.0, true],
+                ["foo", 50.0, false],
+                ["foo", 50.0, false],
+            ],
+            'params' => [
+                ['foo' => 'foo', new \stdClass()],
+                ['foo' => 'foo', new \stdClass(), "bar" => 50.0],
+                ['foo' => 'foo', new \stdClass(), "bar" => 50.0, "baz" => false],
+                ['foo' => 'foo', "bar" => 50.0, new \stdClass(), "baz" => false],
+            ]
+        ];
+        $factory = function ($foo, $bar = 300.0, $baz = true) {
+            return [$foo, $bar, $baz];
+        };
+        foreach ($assetions['expected'] as $idx => $exp) {
+            $res = $this->invoker->call($factory, $assetions['params'][$idx]);
+            $this->assertEquals($exp, $res);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function test_should_override_value_for_trailing_optional_parameters()
+    {
+        $res = $this->invoker->call(function ($foo, $bar = 300.0, $baz = true) {
+            return [$foo, $bar, $baz];
+        }, array(
+            'foo' => 'foo',
+            new \stdClass(),
+            'bar' => 50.0,
+        ));
+        $this->assertEquals(["foo", 50.0, true], $res);
+    }
+
+    /**
+     * @test
+     */
     public function should_do_dependency_injection_with_typehint_container_resolver()
     {
         $resolver = new TypeHintContainerResolver($this->container);


### PR DESCRIPTION
[#24] - Fix issue with factories' optional parameters. NumericArrayResolver was injecting every keys of the provided array which was breaking the factory behavior (FactoryDefinition was injected into the factory).
Copy of PHP-DI[#624](https://github.com/PHP-DI/PHP-DI/issues/628)