### PR TITLE
Support __callStatic and invoke class string without container registration

### DIFF
--- a/src/CallableResolver.php
+++ b/src/CallableResolver.php
@@ -62,7 +62,9 @@ class CallableResolver
             return $callable;
         }
         if (\is_string($callable) && \class_exists($callable) && \method_exists($callable, '__invoke')) {
-            return new $callable;
+            if (!$this->container->has($callable)) {
+                return new $callable;
+            }
         }
         if (\is_array($callable) && \count($callable) === 2) {
             list($class, $parameters) = $callable;

--- a/tests/CallableResolverTest.php
+++ b/tests/CallableResolverTest.php
@@ -129,6 +129,26 @@ class CallableResolverTest extends TestCase
     /**
      * @test
      */
+    public function resolve_invoke_class_string_factory_without_register()
+    {
+        $result = $this->resolver->resolve(InvokerTestClassString::class);
+        $this->assertInstanceOf(\StdClass::class, $result());
+    }
+
+    /**
+     * @test
+     */
+    public function resolve_magic_call_static()
+    {
+        $result = $this->resolver->resolve([InvokerTestCallStaticMagic::class, 'test']);
+        $result = $result();
+        $this->assertInstanceOf(\StdClass::class, $result);
+        $this->assertEquals('test', $result->name);
+    }
+
+    /**
+     * @test
+     */
     public function throws_resolving_non_callable_from_container()
     {
         $this->expectExceptionMessage("'foo' is neither a callable nor a valid container entry");
@@ -163,4 +183,34 @@ class CallableResolverTest extends TestCase
 function foo()
 {
     return 'bar';
+}
+
+class InvokerTestClassString
+{
+    public function __invoke()
+    {
+        return new StdClass();
+    }
+}
+
+class InvokerTestCallStaticMagic
+{
+    private $text;
+
+    final public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function __invoke()
+    {
+        $class = new StdClass();
+        $class->name = $this->name;
+        return $class;
+    }
+
+    public static function __callStatic(string $name, array $arguments): object
+    {
+        return \call_user_func_array(new static($name), $arguments);
+    }
 }


### PR DESCRIPTION
Hi, that fix for supporting factories like this
https://github.com/streamcommon/doctrine-manager/blob/master/lib/AbstractFactory.php `__callStatic`
https://github.com/streamcommon/doctrine-manager/blob/master/lib/ORM/Factory/EntityResolver.php `__invoke`

It was checked together with the module https://github.com/elie29/zend-di-config and configuration
```php
    'dependencies' => [
        'factories' => [
            'doctrine.driver.orm_default'          => [DriverFactory::class, 'orm_default'],
            'doctrine.event_manager.orm_default'   => [EventManagerFactory::class, 'orm_default'],
            'doctrine.configuration.orm_default'   => [ConfigurationFactory::class, 'orm_default'],
            'doctrine.connection.orm_default'      => [ConnectionFactory::class, 'orm_default'],
            'doctrine.entity_resolver.orm_default' => [EntityResolverFactory::class, 'orm_default'],
            'doctrine.entity_manager.orm_default'  => [EntityManagerFactory::class, 'orm_default'],
```
