### PR TITLE
Support PHP 7.1 nullable parameters

### DIFF
--- a/src/ParameterResolver/DefaultValueResolver.php
+++ b/src/ParameterResolver/DefaultValueResolver.php
@@ -30,6 +30,11 @@ class DefaultValueResolver implements ParameterResolver
                 } catch (ReflectionException $e) {
                     // Can't get default values from PHP internal classes and functions
                 }
+            } else {
+                $parameterType = $parameter->getType();
+                if ($parameterType && $parameterType->allowsNull()) {
+                    $resolvedParameters[$index] = null;
+                }
             }
         }
 

--- a/tests/InvokerTest.php
+++ b/tests/InvokerTest.php
@@ -182,6 +182,30 @@ class InvokerTest extends TestCase
     /**
      * @test
      */
+    public function should_invoke_callable_with_null_for_nullable_parameters()
+    {
+        $result = $this->invoker->call(function (?string $baz = null) {
+            return $baz;
+        });
+
+        $this->assertNull($result);
+    }
+
+    /**
+     * @test
+     */
+    public function should_invoke_callable_with_null_for_non_optional_nullable_parameters()
+    {
+        $result = $this->invoker->call(function (?string $baz) {
+            return $baz;
+        });
+
+        $this->assertNull($result);
+    }
+
+    /**
+     * @test
+     */
     public function should_do_dependency_injection_with_typehint_container_resolver()
     {
         $resolver = new TypeHintContainerResolver($this->container);


### PR DESCRIPTION
See https://github.com/PHP-DI/Slim-Bridge/issues/37

`null` will be injected in nullable parameters.

👍  **Works:** 
```php
class SomeController {
    function someAction($request, ?int $id = null) {}
}
```
```php
class SomeController {
    function someAction($request, int $id = null) {}
}
```

👎  **Doesn't Works:**
```php
class SomeController {
    function someAction($request, ?int $id) {}
}
```

**Exception :**
> Exception has occurred.
Invoker\Exception\NotEnoughParametersException: Unable to invoke the callable because no value was given for parameter
