### PR TITLE
Support functions with (non typed) variadic parameters

### DIFF
--- a/src/Invoker.php
+++ b/src/Invoker.php
@@ -62,9 +62,8 @@ class Invoker implements InvokerInterface
 
         // Check all parameters are resolved
         $diff = array_diff_key($callableReflection->getParameters(), $args);
-        /** @var ReflectionParameter $parameter */
-        if (($parameter = reset($diff)) && !$parameter->isVariadic()) {
-            \assert($parameter instanceof ReflectionParameter);
+        $parameter = reset($diff);
+        if ($parameter && \assert($parameter instanceof ReflectionParameter) && ! $parameter->isVariadic()) {
             throw new NotEnoughParametersException(sprintf(
                 'Unable to invoke the callable because no value was given for parameter %d ($%s)',
                 $parameter->getPosition() + 1,

--- a/src/Invoker.php
+++ b/src/Invoker.php
@@ -62,8 +62,8 @@ class Invoker implements InvokerInterface
 
         // Check all parameters are resolved
         $diff = array_diff_key($callableReflection->getParameters(), $args);
-        if (! empty($diff)) {
-            $parameter = reset($diff);
+        /** @var ReflectionParameter $parameter */
+        if (($parameter = reset($diff)) && !$parameter->isVariadic()) {
             \assert($parameter instanceof ReflectionParameter);
             throw new NotEnoughParametersException(sprintf(
                 'Unable to invoke the callable because no value was given for parameter %d ($%s)',

--- a/tests/InvokerTest.php
+++ b/tests/InvokerTest.php
@@ -451,11 +451,11 @@ class InvokerTest extends TestCase
      */
     public function should_invoke_callable_with_variadic_parameter()
     {
-        $result = $this->invoker->call(function (...$param) {
+        $callable = function (...$param) {
             return $param;
-        }, [1, 2, 3]);
-
-        $this->assertEquals([1, 2, 3], $result);
+        };
+        $this->assertEquals([1, 2, 3], $this->invoker->call($callable, [1, 2, 3]), 'non-empty variadic');
+        $this->assertEquals([], $this->invoker->call($callable, []), 'empty variadic');
     }
 
     private function assertWasCalled(CallableSpy $callableSpy)


### PR DESCRIPTION
https://github.com/PHP-DI/Invoker/pull/19#issuecomment-707069728

if no parameter is provided, a variadic function can't be invoked:

```
Invoker\Exception\NotEnoughParametersException: 
Unable to invoke the callable because no value was given for parameter 1 ($param)
```


P.S.
typed variadics don't work at all, im going to do another PR

```php
/**
 * class    -> function(Class ...$args) {}
 * self     -> function(self ...$args) {}
 * array    -> function(array ...$args) {}
 * iterable -> function(iterable ...$args) {}
 * callable -> function(callable ...$args) {}
 */ 
```