### PR TITLE
Allow psr container v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
         "php": ">=7.3",
-        "psr/container": "~1.0"
+        "psr/container": "^1.0|^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/tests/Mock/ArrayContainer.php
+++ b/tests/Mock/ArrayContainer.php
@@ -27,7 +27,7 @@ class ArrayContainer implements ContainerInterface
     }
 
     /** {@inheritDoc} */
-    public function has($id)
+    public function has($id): bool
     {
         return array_key_exists($id, $this->entries);
     }


### PR DESCRIPTION
Only requires new minor version.

See hannesvdvreken/psr-container-v2-demonstrator#1 for an explanation.

Your Mock ArrayContainer works both with v1 and v2. And since it's not part of the public interface of this package, you can safely tag a new minor version.