### PR TITLE
Check "static" callable for method existing in CallableResolver

### DIFF
--- a/src/CallableResolver.php
+++ b/src/CallableResolver.php
@@ -109,6 +109,11 @@ class CallableResolver
     {
         if (is_array($callable) && is_string($callable[0])) {
             [$class, $method] = $callable;
+
+            if (! method_exists($class, $method)) {
+                return false;
+            }
+
             $reflection = new ReflectionMethod($class, $method);
 
             return ! $reflection->isStatic();

--- a/tests/InvokerTest.php
+++ b/tests/InvokerTest.php
@@ -76,6 +76,16 @@ class InvokerTest extends TestCase
     /**
      * @test
      */
+    public function cannot_invoke_static_magic_method()
+    {
+        $this->expectExceptionMessage('Invoker\Test\InvokerTestStaticMagicMethodFixture::foo() is not a callable. A __call() or __callStatic() method exists but magic methods are not supported.');
+        $this->expectException(NotCallableException::class);
+        $this->invoker->call([InvokerTestStaticMagicMethodFixture::class, 'foo']);
+    }
+
+    /**
+     * @test
+     */
     public function should_invoke_static_method()
     {
         $result = $this->invoker->call([InvokerTestStaticFixture::class, 'foo']);
@@ -503,3 +513,18 @@ class InvokerTestMagicMethodFixture
         throw new Exception('Unknown method');
     }
 }
+
+class InvokerTestStaticMagicMethodFixture
+{
+    /** @var bool */
+    public static $wasCalled = false;
+    public static function __callStatic(string $name, array $args): string
+    {
+        if ($name === 'foo') {
+            static::$wasCalled = true;
+            return 'bar';
+        }
+        throw new Exception('Unknown method');
+    }
+}
+


### PR DESCRIPTION
Check if the callable represents a static call to a non-static method only for existing methods

Fixes https://github.com/PHP-DI/Invoker/issues/36