### PR TITLE
Solve https://github.com/PHP-DI/Slim-Bridge/issues/51

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     },
     "require": {
         "php": ">=7.3",
-        "psr/container": "^1.0|^2.0"
+        "psr/container": "^1.0|^2.0",
+        "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/src/CallableResolver.php
+++ b/src/CallableResolver.php
@@ -6,6 +6,7 @@ use Closure;
 use Invoker\Exception\NotCallableException;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
+use Psr\Http\Server\MiddlewareInterface;
 use ReflectionException;
 use ReflectionMethod;
 
@@ -38,6 +39,9 @@ class CallableResolver
         $callable = $this->resolveFromContainer($callable);
 
         if (! is_callable($callable)) {
+            if ($callable instanceof MiddlewareInterface) {
+                return fn ($request, $next) => $callable->process($request, $next);
+            }
             throw NotCallableException::fromInvalidCallable($callable, true);
         }
 

--- a/tests/CallableResolverTest.php
+++ b/tests/CallableResolverTest.php
@@ -6,7 +6,11 @@ use Invoker\CallableResolver;
 use Invoker\Exception\NotCallableException;
 use Invoker\Test\Mock\ArrayContainer;
 use Invoker\Test\Mock\CallableSpy;
+use Invoker\Test\Mock\Psr_15\Middleware;
+use Invoker\Test\Mock\Psr_15\Request;
+use Invoker\Test\Mock\Psr_15\RequestHandler;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
 use stdClass;
 
 class CallableResolverTest extends TestCase
@@ -121,6 +125,20 @@ class CallableResolverTest extends TestCase
 
         $result();
         $this->assertTrue($fixture->wasCalled);
+    }
+
+    /**
+     * @test
+     */
+    public function resolves_psr_15_middleware()
+    {
+        $this->container->set(Middleware::class, new Middleware());
+
+        $result = $this->resolver->resolve(Middleware::class);
+
+        $result = $result(new Request(), new RequestHandler());
+
+        $this->assertInstanceOf(ResponseInterface::class, $result);
     }
 
     /**

--- a/tests/Mock/Psr_15/Middleware.php
+++ b/tests/Mock/Psr_15/Middleware.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Invoker\Test\Mock\Psr_15;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * The mock PSR-15 middleware
+ */
+class Middleware implements MiddlewareInterface
+{
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        return $handler->handle($request);
+    }
+}

--- a/tests/Mock/Psr_15/Request.php
+++ b/tests/Mock/Psr_15/Request.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Invoker\Test\Mock\Psr_15;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
+
+class Request implements ServerRequestInterface
+{
+
+    public function getProtocolVersion()
+    {
+
+    }
+
+    public function withProtocolVersion($version)
+    {
+
+    }
+
+    public function getHeaders()
+    {
+
+    }
+
+    public function hasHeader($name)
+    {
+
+    }
+
+    public function getHeader($name)
+    {
+
+    }
+
+    public function getHeaderLine($name)
+    {
+
+    }
+
+    public function withHeader($name, $value)
+    {
+
+    }
+
+    public function withAddedHeader($name, $value)
+    {
+
+    }
+
+    public function withoutHeader($name)
+    {
+
+    }
+
+    public function getBody()
+    {
+
+    }
+
+    public function withBody(StreamInterface $body)
+    {
+
+    }
+
+    public function getRequestTarget()
+    {
+
+    }
+
+    public function withRequestTarget($requestTarget)
+    {
+
+    }
+
+    public function getMethod()
+    {
+
+    }
+
+    public function withMethod($method)
+    {
+
+    }
+
+    public function getUri()
+    {
+
+    }
+
+    public function withUri(UriInterface $uri, $preserveHost = false)
+    {
+
+    }
+
+    public function getServerParams()
+    {
+
+    }
+
+    public function getCookieParams()
+    {
+
+    }
+
+    public function withCookieParams(array $cookies)
+    {
+
+    }
+
+    public function getQueryParams()
+    {
+
+    }
+
+    public function withQueryParams(array $query)
+    {
+
+    }
+
+    public function getUploadedFiles()
+    {
+
+    }
+
+    public function withUploadedFiles(array $uploadedFiles)
+    {
+
+    }
+
+    public function getParsedBody()
+    {
+
+    }
+
+    public function withParsedBody($data)
+    {
+
+    }
+
+    public function getAttributes()
+    {
+
+    }
+
+    public function getAttribute($name, $default = null)
+    {
+
+    }
+
+    public function withAttribute($name, $value)
+    {
+
+    }
+
+    public function withoutAttribute($name)
+    {
+
+    }
+}

--- a/tests/Mock/Psr_15/RequestHandler.php
+++ b/tests/Mock/Psr_15/RequestHandler.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Invoker\Test\Mock\Psr_15;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class RequestHandler implements RequestHandlerInterface
+{
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        return new Response();
+    }
+}

--- a/tests/Mock/Psr_15/Response.php
+++ b/tests/Mock/Psr_15/Response.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Invoker\Test\Mock\Psr_15;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+class Response implements ResponseInterface
+{
+
+    public function getProtocolVersion()
+    {
+
+    }
+
+    public function withProtocolVersion($version)
+    {
+
+    }
+
+    public function getHeaders()
+    {
+
+    }
+
+    public function hasHeader($name)
+    {
+
+    }
+
+    public function getHeader($name)
+    {
+
+    }
+
+    public function getHeaderLine($name)
+    {
+
+    }
+
+    public function withHeader($name, $value)
+    {
+
+    }
+
+    public function withAddedHeader($name, $value)
+    {
+
+    }
+
+    public function withoutHeader($name)
+    {
+
+    }
+
+    public function getBody()
+    {
+
+    }
+
+    public function withBody(StreamInterface $body)
+    {
+
+    }
+
+    public function getStatusCode()
+    {
+
+    }
+
+    public function withStatus($code, $reasonPhrase = '')
+    {
+
+    }
+
+    public function getReasonPhrase()
+    {
+
+    }
+}


### PR DESCRIPTION
It fixes php-di/slim-bridge#51

This package is a dependency of ```php-di/slim-bridge```.

I remind that the ```php-di/Invoker``` breakes the PSR-15 middleware resolving in the Slim microframework. When one writes 
```$app->add(SomeMiddleware::class)``` it causes displaying ```NotCallableException```.

To fix it - a couple of the code strings should be added (see below).

What was generally done in the pull-request code:

**1\)** Adding the ```psr/http-server-middleware``` package to the ```require``` (composer.json) section to have ```MiddlewareInterface```

**2\)** Adding to the ```resolve``` method of the ```Invoker\CallableResolver``` class the following code:
```php
if ($callable instanceof MiddlewareInterface) {
    return fn ($request, $next) => $callable->process($request, $next);
}
```
            
**3\)** Adding a unit-test method checking middleware resolving

**4\)** Adding four mock classes for the new test method: ```Middleware```, ```Request```, ```RequestHandler```, ```Response```

Also I want you to pay attention that the ```php-di/slim-bridge``` package has the performance problem: its dependency (this package) duplicates the routing code from the ```Slim\Routing\Route``` class. See detailed information - https://github.com/PHP-DI/Slim-Bridge/issues/51#issuecomment-941719103
