### PR TITLE
Switch condition order to support PHP 8

### DIFF
--- a/src/ParameterResolver/Container/TypeHintContainerResolver.php
+++ b/src/ParameterResolver/Container/TypeHintContainerResolver.php
@@ -41,12 +41,12 @@ class TypeHintContainerResolver implements ParameterResolver
                 // No type
                 continue;
             }
-            if ($parameterType->isBuiltin()) {
-                // Primitive types are not supported
-                continue;
-            }
             if (! $parameterType instanceof ReflectionNamedType) {
                 // Union types are not supported
+                continue;
+            }
+            if ($parameterType->isBuiltin()) {
+                // Primitive types are not supported
                 continue;
             }
 

--- a/src/ParameterResolver/TypeHintResolver.php
+++ b/src/ParameterResolver/TypeHintResolver.php
@@ -30,12 +30,12 @@ class TypeHintResolver implements ParameterResolver
                 // No type
                 continue;
             }
-            if ($parameterType->isBuiltin()) {
-                // Primitive types are not supported
-                continue;
-            }
             if (! $parameterType instanceof ReflectionNamedType) {
                 // Union types are not supported
+                continue;
+            }
+            if ($parameterType->isBuiltin()) {
+                // Primitive types are not supported
                 continue;
             }
 


### PR DESCRIPTION
In PHP 8, `ReflectionType::isBuiltin()` [has been moved](https://www.php.net/manual/en/class.reflectiontype.php#reflectiontype.changelog) to `ReflectionNamedType::isBuiltin()` and thus should be called after asserting that it's a named type.