### PR TITLE
Skip "optional before required" test for PHP >= 8.1.

### DIFF
--- a/tests/InvokerTest.php
+++ b/tests/InvokerTest.php
@@ -216,10 +216,16 @@ class InvokerTest extends TestCase
 
     /**
      * @see https://github.com/PHP-DI/PHP-DI/issues/562
+     * @deprecated
      * @test
      */
     public function should_invoke_callable_with_optional_parameter_before_required_parameter()
     {
+        if (version_compare(PHP_VERSION, '8.1') >= 0) {
+            /** @see https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.core.optional-before-required */
+            $this->markTestSkipped('An optional parameter specified before required parameters is now always treated as required.');
+        }
+
         $result = $this->invoker->call(function ($baz = 'abc', $foo) {
             return [$baz, $foo];
         }, [


### PR DESCRIPTION
Since [PHP 8.1 optional parameters before required are deprecated](https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.core.optional-before-required). Therefore in `DefaultValueResolver::getParameters()` method a call to the reflection parameter `$parameter->isDefaultValueAvailable()` will always return false, even if the default value is there, when optional parameter is placed before required. So it'll always throw exception of missing parameter when test is running on PHP >= 8.1. I marked it as skipped for now, but I guess later it can be removed, because this behavior won't be supported.
