### PR TITLE
Replace `call_user_func_array` with native invocation

### DIFF
--- a/src/Invoker.php
+++ b/src/Invoker.php
@@ -57,7 +57,8 @@ class Invoker implements InvokerInterface
 
         $args = $this->parameterResolver->getParameters($callableReflection, $parameters, []);
 
-        // Sort by array key because call_user_func_array ignores numeric keys
+        // Sort by array keys is needed since the resolved arguments returned by the resolver are indexed by numeric keys
+        // that correspond to the parameters of the callable, but may be out of order.
         ksort($args);
 
         // Check all parameters are resolved
@@ -71,7 +72,7 @@ class Invoker implements InvokerInterface
             ));
         }
 
-        return call_user_func_array($callable, $args);
+        return $callable(...$args);
     }
 
     /**


### PR DESCRIPTION
addresses #51

Also, I changed the misleading comment about the reason why the keys are sorted.
Simply put, the parameter resolver returns the parameters out of order and even discards the string keys, so they need to be sorted according their numeric indexes, which correspond to the order of parameters in the callables.
